### PR TITLE
check connection

### DIFF
--- a/lib/Mojo/Server/Daemon.pm
+++ b/lib/Mojo/Server/Daemon.pm
@@ -108,6 +108,12 @@ sub _build_tx {
 
       # Last keep-alive request or corrupted connection
       my $c = $self->{connections}{$id};
+
+      unless ($c) {
+          $self->app->log->warn("There is no connection $id now. Maybe disconnected by the pair because this tx took too long time");
+          return;
+      }
+
       $tx->res->headers->connection('close')
         if $c->{requests} >= $self->max_requests || $tx->req->error;
 


### PR DESCRIPTION
When bom-rpc execute more than 20 seconds, websocketapi will close the stream and then bom-rpc will generate a warning
```
Use of uninitialized value in numeric ge (>=) at lib/perl5/Mojo/Server/Daemon.pm line 112.
```
we need to handle this case gracefully.